### PR TITLE
Fix for html encoded letters

### DIFF
--- a/script/common/handlebars.js
+++ b/script/common/handlebars.js
@@ -36,6 +36,6 @@ function preloadHandlebarsTemplates() {
 function registerHandlebarsHelpers() {
   Handlebars.registerHelper("removeMarkup", function (text) {
     const markup = /<(.*?)>/gi;
-    return text.replace(markup, "");
+    return new Handlebars.SafeString(text.replace(markup, ""));
   });
 }

--- a/template/chat/item.html
+++ b/template/chat/item.html
@@ -32,14 +32,14 @@
         {{/if}}
 
         {{#if isTrait}}
-        <p><strong>{{localize "TRAIT.DESCRIPTION"}}:</strong> {{data.description}}</p>
+        <p><strong>{{localize "TRAIT.DESCRIPTION"}}:</strong> {{removeMarkup data.description}}</p>
         <p><strong>{{localize "TITLE.NOVICE"}} [{{data.novice.action}}]:</strong> {{removeMarkup data.novice.description}}</p>
         <p><strong>{{localize "TITLE.ADEPT"}} [{{data.adept.action}}]:</strong> {{removeMarkup data.adept.description}}</p>
         <p><strong>{{localize "TITLE.MASTER"}} [{{data.master.action}}]:</strong> {{removeMarkup data.master.description}}</p>
         {{/if}}
 
         {{#if isAbility}}
-        <p><strong>{{localize "ABILITY.DESCRIPTION"}}:</strong> {{data.description}}</p>
+        <p><strong>{{localize "ABILITY.DESCRIPTION"}}:</strong> {{removeMarkup data.description}}</p>
         <p><strong>{{localize "TITLE.NOVICE"}} [{{data.novice.action}}]:</strong> {{removeMarkup data.novice.description}}</p>
         <p><strong>{{localize "TITLE.ADEPT"}} [{{data.adept.action}}]:</strong> {{removeMarkup data.adept.description}}</p>
         <p><strong>{{localize "TITLE.MASTER"}} [{{data.master.action}}]:</strong> {{removeMarkup data.master.description}}</p>
@@ -79,7 +79,7 @@
         {{/if}}
 
         {{#if isArtifact}}
-        <p><strong>{{localize "ARTIFACT.DESCRIPTION"}}:</strong> {{data.description}}</p>
+        <p><strong>{{localize "ARTIFACT.DESCRIPTION"}}:</strong> {{removeMarkup data.description}}</p>
         <p><strong>{{localize "ARTIFACT.POWER"}} [{{data.action}}]:</strong> {{data.powers}}</p>
         <p><strong>{{localize "ARTIFACT.CORRUPTION"}}:</strong> {{data.corruption}}</p>
         {{/if}}


### PR DESCRIPTION
This is due to how the text editor in Foundry deals with it.  Resolved by using handlebars.SafeString(...) 
#16 