### PR TITLE
Sync activated to show 3drolls on remote machines

### DIFF
--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -34,7 +34,7 @@ export async function rollAttribute(actor, actingAttributeName, targetActor, tar
       
       armorRoll.roll();
       if (game.dice3d != null) {
-        await game.dice3d.showForRoll(armorRoll);
+        await game.dice3d.showForRoll(armorRoll, game.user, true);
       }
       
       armorResults.name = armor.armor;
@@ -56,7 +56,7 @@ export async function rollAttribute(actor, actingAttributeName, targetActor, tar
       let tooltip = await weaponRoll.getTooltip();
       
       if (game.dice3d != null) {
-        await game.dice3d.showForRoll(weaponRoll);
+        await game.dice3d.showForRoll(weaponRoll, game.user, true);
       }
       
       weaponResults.value = weaponRoll.total;
@@ -111,7 +111,7 @@ export async function deathRoll(sheet) {
   let death = new Roll('1d20', {});
   death.roll();
   if (game.dice3d != null) {
-    await game.dice3d.showForRoll(death);
+    await game.dice3d.showForRoll(death, game.user, true);
   }
   let hasSucceed = death._total >= 2 && death._total <= 10;
   let isCriticalSuccess = death._total === 1;
@@ -120,7 +120,7 @@ export async function deathRoll(sheet) {
   let heal = new Roll('1d4', {});
   heal.roll();
   if (game.dice3d != null) {
-    await game.dice3d.showForRoll(heal);
+    await game.dice3d.showForRoll(heal, game.user, true);
   }
   let rollData = {
     isCriticalSuccess: isCriticalSuccess,
@@ -210,7 +210,7 @@ export async function baseRoll(actor, actingAttributeName, targetActor, targetAt
   };
   
   if (game.dice3d != null) {
-    await game.dice3d.showForRoll(attributeRoll);
+    await game.dice3d.showForRoll(attributeRoll, game.user, true);
   }
   
   diceBreakdown = formatDice(attributeRoll.terms,"+");


### PR DESCRIPTION
https://gitlab.com/riccisi/foundryvtt-dice-so-nice/-/wikis/API/Roll

/**
 * Show the 3D Dice animation for the Roll made by the User.
 *
 * @param {Roll} roll an instance of Roll class to show 3D dice animation.
 * @param {User} user the user who made the roll (game.user by default).
 * @param {Boolean} synchronize if the animation needs to be shown to other players. Default: false
 * @param {Array} whisper list of users or userId who can see the roll, set it to null if everyone can see. Default: null
 * @param {Boolean} blind if the roll is blind for the current user. Default: false 
 * @param {String} A chatMessage ID to reveal when the roll ends. Default: null
 * @param {Object} An object using the same data schema than ChatSpeakerData. 
 *        Needed to hide NPCs roll when the GM enables this setting.
 * @returns {Promise<boolean>} when resolved true if the animation was displayed, false if not.
 */
game.dice3d.showForRoll(roll, user, synchronize, whisper, blind, chatMessageID, speaker)